### PR TITLE
Update EDM config to match current configuration

### DIFF
--- a/edm-extractor/edm-config-sample.yml
+++ b/edm-extractor/edm-config-sample.yml
@@ -1,9 +1,8 @@
 cognite:
   apiUrl: "https://api.cognitedata.com"
-  apiKey: "someapikey"
   # clientId: "34efdeoefjefe23"
   # clientSecret: "zecret"
-  # token_url: https://login.microsoftonline.com/...
+  # token_url: https://login.windows.net/<AAD tenant uuid>/oauth2/v2.0/token
   project: "yourtenantprojectname"
   rawDatabaseName: "EdmConnector"
   # queueBufferSize: 500
@@ -34,7 +33,7 @@ edm:
   startPadding: 180
   # connectTimeout: 5
   # readTimeout: 120
-  krontabCompleteExtractSchedule: "0 0 18 * *"
+  crontabComplete: "0 0 18 * *"
   # About once a week we sync and verify if anything has been deleted
   consistencySchedule: "0 30 18 1,8,15,23 *"
   # measurementSystem: yourMeasurementSystem


### PR DESCRIPTION
The name of the complete crontab property was changed.

This aligns it again with edm-connector example. Reported by Peter.